### PR TITLE
📘 リリースノートで `機能追加` もカテゴリ分けできるようにする close #130

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -46,6 +46,9 @@ changelog:
     - title: ⚡️ リファクタリング
       labels:
         - ⚡️ リファクタリング
+    - title: ✨ 機能追加
+      labels:
+        - ✨ 機能追加
     - title: 🎉 新機能
       labels:
         - "*"


### PR DESCRIPTION
 close #130